### PR TITLE
Replace deprecated CSS minifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-react": "^7.33.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "mini-css-extract-plugin": "^2.7.6",
-    "optimize-css-assets-webpack-plugin": "^6.0.1",
+    "css-minimizer-webpack-plugin": "^7.0.2",
     "postcss": "^8.4.31",
     "postcss-loader": "^7.3.3",
     "rimraf": "^5.0.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
-const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 
 const isProduction = process.env.NODE_ENV === 'production';
 
@@ -122,7 +122,7 @@ module.exports = {
                     }
                 }
             }),
-            ...(isProduction ? [new OptimizeCSSAssetsPlugin()] : [])
+            ...(isProduction ? [new CssMinimizerPlugin()] : [])
         ],
         splitChunks: {
             chunks: 'all',


### PR DESCRIPTION
## Summary
- remove `optimize-css-assets-webpack-plugin` from dev dependencies
- add `css-minimizer-webpack-plugin` and configure webpack to use it for CSS minification

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6894ab713f88832687959820899a1617