### PR TITLE
feat: sanitize HTML content client-side

### DIFF
--- a/components/pages/AboutPage.tsx
+++ b/components/pages/AboutPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Building, Target, Eye, Heart, Scale, Users } from 'lucide-react';
 
@@ -116,9 +117,11 @@ export default function AboutPage({ pageData }: AboutPageProps) {
         <div className="mb-12">
           <Card>
             <CardContent className="p-8">
-              <div 
+              <div
                 className="prose prose-lg max-w-none"
-                dangerouslySetInnerHTML={{ __html: data.content?.rendered || '' }}
+                dangerouslySetInnerHTML={{
+                  __html: DOMPurify.sanitize(data.content?.rendered || ''),
+                }}
               />
             </CardContent>
           </Card>

--- a/components/pages/ContactPage.tsx
+++ b/components/pages/ContactPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import DOMPurify from 'dompurify';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { Input } from '../ui/input';
@@ -219,9 +220,11 @@ export default function ContactPage({ pageData }: ContactPageProps) {
             {pageData?.content?.rendered && (
               <Card>
                 <CardContent className="p-6">
-                  <div 
+                  <div
                     className="prose prose-sm max-w-none"
-                    dangerouslySetInnerHTML={{ __html: pageData.content.rendered }}
+                    dangerouslySetInnerHTML={{
+                      __html: DOMPurify.sanitize(pageData.content.rendered),
+                    }}
                   />
                 </CardContent>
               </Card>

--- a/components/pages/MeetingDetailPage.tsx
+++ b/components/pages/MeetingDetailPage.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import DOMPurify from "dompurify";
 import {
   Card,
   CardContent,
@@ -77,7 +78,11 @@ export default function MeetingDetailPage({ meetingId, onNavigate }: MeetingDeta
           </div>
 
           {meeting.content?.rendered && (
-            <div dangerouslySetInnerHTML={{ __html: meeting.content.rendered }} />
+            <div
+              dangerouslySetInnerHTML={{
+                __html: DOMPurify.sanitize(meeting.content.rendered),
+              }}
+            />
           )}
 
           {attachments.length > 0 && (

--- a/components/pages/PresidentPage.tsx
+++ b/components/pages/PresidentPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
 import { User, GraduationCap, Briefcase, MessageCircle } from 'lucide-react';
 import { ImageWithFallback } from '../figma/ImageWithFallback';
@@ -162,9 +163,13 @@ export default function PresidentPage({ pageData }: PresidentPageProps) {
                 </CardTitle>
               </CardHeader>
               <CardContent>
-                <div 
+                <div
                   className="prose prose-sm max-w-none text-muted-foreground"
-                  dangerouslySetInnerHTML={{ __html: data.content?.rendered || content.biografia }}
+                  dangerouslySetInnerHTML={{
+                    __html: DOMPurify.sanitize(
+                      data.content?.rendered || content.biografia,
+                    ),
+                  }}
                 />
               </CardContent>
             </Card>

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "clsx": "^2.0.0",
     "cmdk": "^0.2.0",
     "date-fns": "^2.30.0",
+    "dompurify": "^3.0.6",
     "embla-carousel-react": "^8.0.0",
     "input-otp": "^1.2.4",
     "lucide-react": "^0.290.0",


### PR DESCRIPTION
## Summary
- sanitize meeting details and informational pages with DOMPurify
- declare dompurify dependency

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run type-check` *(help output shown, tsconfig missing)*


------
https://chatgpt.com/codex/tasks/task_e_6894ab86b7f88326b2d0c15cc8f699cc